### PR TITLE
VEN-365 | Update docker configuration to be more production-ready

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+node_modules
+npm-debug.log
+Dockerfile*
+docker-compose*
+.dockerignore
+.git
+.gitignore
+.gitlab-ci.yml
+.travis.yml
+README.md
+LICENSE
+.vscode

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ build-review:
   extends: .build
   variables:
     DOCKER_IMAGE_NAME: "$CI_PROJECT_NAME-review"
-    DOCKER_BUILD_ARG_NODE_ENV: "development"
+    DOCKER_BUILD_ARG_DEBUG: "debug"
     DOCKER_BUILD_ARG_OPEN_CITY_PROFILE_API_URL: "https://helsinkiprofile.test.kuva.hel.ninja/graphql/"
     DOCKER_BUILD_ARG_BERTH_RESERVATIONS_API_URL: "https://venepaikka-api.test.hel.ninja/graphql_v2/"
   only:
@@ -21,7 +21,7 @@ build-staging:
   extends: .build
   variables:
     DOCKER_IMAGE_NAME: "$CI_PROJECT_NAME-staging"
-    DOCKER_BUILD_ARG_NODE_ENV: "development"
+    DOCKER_BUILD_ARG_DEBUG: "debug"
     DOCKER_BUILD_ARG_OPEN_CITY_PROFILE_API_URL: "https://helsinkiprofile.test.kuva.hel.ninja/graphql/"
     DOCKER_BUILD_ARG_BERTH_RESERVATIONS_API_URL: "https://venepaikka-api.test.hel.ninja/graphql_v2/"
   only:
@@ -32,7 +32,6 @@ build-production:
   extends: .build
   variables:
     DOCKER_IMAGE_NAME: "$CI_PROJECT_NAME-production"
-    DOCKER_BUILD_ARG_NODE_ENV: "production"
     DOCKER_BUILD_ARG_OPEN_CITY_PROFILE_API_URL: ""
     DOCKER_BUILD_ARG_BERTH_RESERVATIONS_API_URL: ""
   only:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -28,6 +28,5 @@ if [[ ! -z "$@" ]]; then
 elif [[ "$DEV_SERVER" = "1" ]]; then
     npm start
 else
-    # TODO: Configure production setup
-    npm start
+    npm run serve
 fi

--- a/package.json
+++ b/package.json
@@ -1,19 +1,23 @@
 {
-  "name": "federation",
+  "name": "berth-federation",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {
     "start": "nodemon --ext ts --exec 'ts-node' src/index.ts",
+    "transpile": "tsc",
+    "serve": "node dist/index.js",
     "test": "echo \"Error: no test specified, everything must work\" && exit 0"
   },
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "dependencies": {
     "@apollo/gateway": "^0.8.1",
     "apollo-server": "^2.9.8",
     "dotenv": "^8.2.0",
-    "graphql": "^14.4.2",
+    "graphql": "^14.4.2"
+  },
+  "devDependencies": {
     "nodemon": "^1.19.1",
     "ts-node": "^8.3.0",
     "typescript": "^3.5.3"


### PR DESCRIPTION
Since we have Kubernetes infrastructure, we can serve our Express
JS application simply using `node` binary. We don't need any
process managers like pm2 (or at least do not need it yet).
However, we need to transpile Typescript source to Javascript
first, before serving the JS files. To do that we now have a
more complex Dockerfile, with several stages:
1. appbase has the common layers
2. development_base has the layers applicable for development
   environment and for the `npm run transpiler` command
3. development starts a local dev env
4. transpiler stage transpile TS to JS
5. production starts ~production-ready server

Refs VEN-365