### PR TITLE
VEN-392 | Check downstream services for schema updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@apollo/gateway": "^0.8.1",
-    "apollo-server": "^2.9.8",
+    "@apollo/gateway": "^0.11.7",
+    "apollo-server": "^2.9.16",
     "dotenv": "^8.2.0",
     "graphql": "^14.4.2"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,7 @@ const gateway = new ApolloGateway({
     buildService({ name, url }) {
         return new AuthenticatedDataSource({ name, url });
     },
+    experimental_pollInterval: 600000,  // every 10 min
 });
 
 


### PR DESCRIPTION
1. Update apollo dependencies to use this experimental polling
   feature.
2. Poll downstream services every 10 mins to check for schema
   updates.

Refs VEN-392