### PR TITLE
New KUVA ci backend

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,7 +12,7 @@ build-review:
     DOCKER_IMAGE_NAME: "$CI_PROJECT_NAME-review"
     DOCKER_BUILD_ARG_DEBUG: "debug"
     DOCKER_BUILD_ARG_OPEN_CITY_PROFILE_API_URL: "https://profiili-api.test.kuva.hel.ninja/graphql/"
-    DOCKER_BUILD_ARG_BERTH_RESERVATIONS_API_URL: "https://venepaikka-api.test.hel.ninja/graphql_v2/"
+    DOCKER_BUILD_ARG_BERTH_RESERVATIONS_API_URL: "https://venepaikka-api.test.kuva.hel.ninja/graphql_v2/"
   only:
     refs:
       - external_pull_requests
@@ -23,7 +23,7 @@ build-staging:
     DOCKER_IMAGE_NAME: "$CI_PROJECT_NAME-staging"
     DOCKER_BUILD_ARG_DEBUG: "debug"
     DOCKER_BUILD_ARG_OPEN_CITY_PROFILE_API_URL: "https://profiili-api.test.kuva.hel.ninja/graphql/"
-    DOCKER_BUILD_ARG_BERTH_RESERVATIONS_API_URL: "https://venepaikka-api.test.hel.ninja/graphql_v2/"
+    DOCKER_BUILD_ARG_BERTH_RESERVATIONS_API_URL: "https://venepaikka-api.test.kuva.hel.ninja/graphql_v2/"
   only:
     refs:
       - develop


### PR DESCRIPTION
Change urls to new KUVA ci hosted backend for review and staging environments. Enables testing the backend staging env.