### PR TITLE
Fix all references to the old API url

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -29,7 +29,7 @@ jobs:
           DOCKER_IMAGE_NAME: ${{ env.REPO_NAME }}-review
           DOCKER_BUILD_ARG_DEBUG: "debug"
           DOCKER_BUILD_ARG_OPEN_CITY_PROFILE_API_URL: "https://profiili-api.test.kuva.hel.ninja/graphql/"
-          DOCKER_BUILD_ARG_BERTH_RESERVATIONS_API_URL: "https://venepaikka-api.test.kuva.hel.ninja/graphql_v2/"
+          DOCKER_BUILD_ARG_BERTH_RESERVATIONS_API_URL: "https://venepaikka-api.test.kuva.hel.ninja/graphql/"
 
   review:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This specific gateway combines two projects:
       setups for each project
     * you can use the test instances managed by the City of Helsinki:
         - https://profiili-api.test.kuva.hel.ninja/graphql/ for profile
-        - https://venepaikka-api.test.hel.ninja/graphql_v2/ for berths
+        - https://venepaikka-api.test.kuva.hel.ninja/graphql/ for berths
 
 3. Adjust other variables according to your needs.
 

--- a/docker-compose.env.yaml.example
+++ b/docker-compose.env.yaml.example
@@ -3,4 +3,4 @@ DEBUG=debug
 NODE_ENV=development
 PORT=3000
 OPEN_CITY_PROFILE_API_URL=http://profile-backend:8080/graphql/
-BERTH_RESERVATIONS_API_URL=http://berth:8040/graphql_v2/
+BERTH_RESERVATIONS_API_URL=http://berth:8040/graphql/


### PR DESCRIPTION
## Description :sparkles:
* Remove all references to the old `v2` API