### PR TITLE
VEN-1401 | Use Kanslia's test HKI Profile in staging env

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -28,7 +28,7 @@ jobs:
         env:
           DOCKER_IMAGE_NAME: ${{ env.REPO_NAME }}-review
           DOCKER_BUILD_ARG_DEBUG: "debug"
-          DOCKER_BUILD_ARG_OPEN_CITY_PROFILE_API_URL: "https://profiili-api.test.kuva.hel.ninja/graphql/"
+          DOCKER_BUILD_ARG_OPEN_CITY_PROFILE_API_URL: "https://profile-api.test.hel.ninja/graphql/"
           DOCKER_BUILD_ARG_BERTH_RESERVATIONS_API_URL: "https://venepaikka-api.test.kuva.hel.ninja/graphql/"
 
   review:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -38,7 +38,7 @@ jobs:
         env:
           DOCKER_IMAGE_NAME: ${{ env.REPO_NAME }}-staging
           DOCKER_BUILD_ARG_DEBUG: "debug"
-          DOCKER_BUILD_ARG_OPEN_CITY_PROFILE_API_URL: "https://profiili-api.test.kuva.hel.ninja/graphql/"
+          DOCKER_BUILD_ARG_OPEN_CITY_PROFILE_API_URL: "https://profile-api.test.hel.ninja/graphql/"
           DOCKER_BUILD_ARG_BERTH_RESERVATIONS_API_URL: "https://venepaikka-api.test.kuva.hel.ninja/graphql/"
 
   staging:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This specific gateway combines two projects:
     * current placeholder in the template will work if you use default docker-compose
       setups for each project
     * you can use the test instances managed by the City of Helsinki:
-        - https://profiili-api.test.kuva.hel.ninja/graphql/ for profile
+        - https://profile-api.test.hel.ninja/graphql/ for profile
         - https://venepaikka-api.test.kuva.hel.ninja/graphql/ for berths
 
 3. Adjust other variables according to your needs.
@@ -40,4 +40,4 @@ PORT you specified in the `docker-compose.env.yaml`)
 
 Test environment: https://venepaikka-federation.test.kuva.hel.ninja/
 
-Voyager graph of all Quieries: https://venepaikka-federation.test.kuva.hel.ninja/voyager
+Voyager graph of all Queries: https://venepaikka-federation.test.kuva.hel.ninja/voyager


### PR DESCRIPTION
## Description :sparkles:

Switch the staging and review environments to use Kanslia's test Tunnistamo and HKI Profile to be able to test Suomi.fi strong authentication.

## Issues :bug:
### Related :handshake:
**[VEN-1401](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1401)** 


## Testing :alembic:

### Manual testing :construction_worker_man:

It is not possible to fully test this before merging, but most parts can be tested locally. 

## Additional notes :spiral_notepad:

Currently it is not possible to get PR environments' authentication to actually work with Kanslia's Tunnistamo, but those envs are not working at the moment anyway, so we switch them to Kanslia's Tunnistamo to prevent confusion in the future.