### PR TITLE
Add API connection check to the health check

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "apollo-server": "^2.9.16",
     "dotenv": "^8.2.0",
     "graphql": "^14.4.2",
-    "graphql-voyager": "^1.0.0-rc.28"
+    "graphql-voyager": "^1.0.0-rc.28",
+    "node-fetch": "^2.6.6"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.155",

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,11 @@ const gateway = new ApolloGateway({
   buildService({ name, url }) {
     return new AuthenticatedDataSource({ name, url });
   },
-  experimental_pollInterval: 600000, // every 10 min
+  // "Polling running services is dangerous and not recommended in production.
+  // Polling should only be used against a registry.
+  // If you are polling running services, use with caution"
+  // - https://github.com/apollographql/apollo-server/discussions/4280.
+  // experimental_pollInterval: 600000, // every 10 min
 });
 
 (async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,73 +1,97 @@
 import { ApolloServer } from "apollo-server-express";
-import { ApolloGateway } from '@apollo/gateway';
+import { ApolloGateway } from "@apollo/gateway";
 import * as cors from "cors";
-import * as dotenv  from "dotenv";
+import * as dotenv from "dotenv";
 import * as express from "express";
-import { AuthenticatedDataSource } from "./dataSources"
+import { AuthenticatedDataSource } from "./dataSources";
+import {
+  berthReservationsBackend,
+  openCityProfileBackend,
+  testConnectionToBerthReservationsBackend,
+  testConnectionToOpenCityProfileBackend,
+} from "./services";
 
 dotenv.config();
 
-const debug: boolean = process.env.DEBUG === "debug" || process.env.NODE_ENV !== "production";
+const debug: boolean =
+  process.env.DEBUG === "debug" || process.env.NODE_ENV !== "production";
 
 const port: string = process.env.PORT || "3000";
-const openCityProfileBackend: string = process.env.OPEN_CITY_PROFILE_API_URL;
-const berthReservationsBackend: string = process.env.BERTH_RESERVATIONS_API_URL;
 
 const gateway = new ApolloGateway({
-    serviceList: [
-        // name of the service is the same as its API scope for auth purposes
-        { name: "https://api.hel.fi/auth/helsinkiprofile", url: openCityProfileBackend },
-        { name: "https://api.hel.fi/auth/berths", url: berthReservationsBackend },
-    ],
-    buildService({ name, url }) {
-        return new AuthenticatedDataSource({ name, url });
+  serviceList: [
+    // name of the service is the same as its API scope for auth purposes
+    {
+      name: "https://api.hel.fi/auth/helsinkiprofile",
+      url: openCityProfileBackend,
     },
-    experimental_pollInterval: 600000,  // every 10 min
+    { name: "https://api.hel.fi/auth/berths", url: berthReservationsBackend },
+  ],
+  buildService({ name, url }) {
+    return new AuthenticatedDataSource({ name, url });
+  },
+  experimental_pollInterval: 600000, // every 10 min
 });
 
-
 (async () => {
-    const server = new ApolloServer({
-        gateway,
-        subscriptions: false,
-        context: ({ req }) => {
-            const apiTokens: string = req.headers["api-tokens"] || "";
-            const acceptLanguage: string = req.headers["accept-language"] || "";
-            return { apiTokens, acceptLanguage };
+  const server = new ApolloServer({
+    gateway,
+    subscriptions: false,
+    context: ({ req }) => {
+      const apiTokens: string = req.headers["api-tokens"] || "";
+      const acceptLanguage: string = req.headers["accept-language"] || "";
+      return { apiTokens, acceptLanguage };
+    },
+    debug: debug,
+    playground: debug,
+    introspection: debug,
+  });
+
+  const app = express();
+
+  app.use(cors());
+
+  // GraphQL Voyager schema visualization
+  if (debug) {
+    const voyagerMiddleware = require("graphql-voyager/middleware").express;
+    app.use(
+      "/voyager",
+      voyagerMiddleware({
+        endpointUrl: "/graphql",
+        displayOptions: {
+          sortByAlphabet: true,
         },
-        debug: debug,
-        playground: debug,
-        introspection: debug
-    });
-
-    const app = express();
-
-    app.use(cors());
-
-    // GraphQL Voyager schema visualization
-    if (debug) {
-        const voyagerMiddleware = require('graphql-voyager/middleware').express;
-        app.use('/voyager', voyagerMiddleware({
-            endpointUrl: '/graphql',
-            displayOptions: {
-                sortByAlphabet: true,
-            },
-        }));
-    }
-
-    // TODO: check that app actually works
-    app.get("/readiness", ( req, res ) => {
-        res.status(200).json({status: "OK"});
-    });
-
-    app.get( "/healthz", ( req, res ) => {
-        res.status(200).json({status: "OK"});
-    });
-
-    server.applyMiddleware({ app, path: "/" });
-
-    app.listen({ port }, () =>
-        // eslint-disable-next-line no-console
-        console.log(`🚀 Server ready at http://localhost:${port}`)
+      })
     );
+  }
+
+  // TODO: check that app actually works
+  app.get("/readiness", (req, res) => {
+    res.status(200).json({ status: "OK" });
+  });
+
+  app.get("/healthz", async (req, res) => {
+    const isBerthApiHealthy = await testConnectionToBerthReservationsBackend();
+    const isProfileApiHealthy = await testConnectionToOpenCityProfileBackend();
+    let messages: string[] = [];
+    if (!isBerthApiHealthy) {
+      messages.push("Connection issues with the Berth API.");
+    }
+    if (!isProfileApiHealthy) {
+      messages.push("Connection issues with the Open City Profile API.");
+    }
+    // 504 Gateway Timeout
+    if (messages.length > 0) {
+      res.status(504).json({ status: "ERROR", messages });
+    } else {
+      res.status(200).json({ status: "OK" });
+    }
+  });
+
+  server.applyMiddleware({ app, path: "/" });
+
+  app.listen({ port }, () =>
+    // eslint-disable-next-line no-console
+    console.log(`🚀 Server ready at http://localhost:${port}`)
+  );
 })();

--- a/src/services.ts
+++ b/src/services.ts
@@ -1,0 +1,42 @@
+import fetch from "node-fetch";
+
+export const openCityProfileBackend: string =
+  process.env.OPEN_CITY_PROFILE_API_URL;
+export const berthReservationsBackend: string =
+  process.env.BERTH_RESERVATIONS_API_URL;
+
+export const defaultHealthCheckPath = "/healthz";
+
+export const getDefaultBackendReadinessEndpoint = (url: string) => {
+  const origin = new URL(url).origin;
+  const healthCheckEndpoint = new URL(defaultHealthCheckPath, origin);
+  return healthCheckEndpoint.href;
+};
+
+export const testConnectionToBerthReservationsBackend = async () => {
+  const healthCheckEndpoint = getDefaultBackendReadinessEndpoint(
+    berthReservationsBackend
+  );
+  const response = await fetch(healthCheckEndpoint).catch((error) =>
+    console.error(error)
+  );
+  if (!response || response.status !== 200) {
+    console.warn("The connection to the Berth API is not healthy.");
+    return false;
+  }
+  return true;
+};
+
+export const testConnectionToOpenCityProfileBackend = async () => {
+  const healthCheckEndpoint = getDefaultBackendReadinessEndpoint(
+    openCityProfileBackend
+  );
+  const response = await fetch(healthCheckEndpoint).catch((error) =>
+    console.error(error)
+  );
+  if (!response || response.status !== 200) {
+    console.warn("The connection to the Open City Profile is not healthy.");
+    return false;
+  }
+  return true;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2397,6 +2397,13 @@ node-fetch@^2.1.2, node-fetch@^2.2.0:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
+node-fetch@^2.6.6:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
+
 nodemon@^1.19.1:
   version "1.19.4"
   resolved "https://registry.yarnpkg.com/nodemon/-/nodemon-1.19.4.tgz#56db5c607408e0fdf8920d2b444819af1aae0971"
@@ -3130,6 +3137,11 @@ touch@^3.1.0:
   dependencies:
     nopt "~1.0.10"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
+
 ts-invariant@^0.4.0:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.4.4.tgz#97a523518688f93aafad01b0e80eb803eb2abd86"
@@ -3316,10 +3328,23 @@ warning@^4.0.1:
   dependencies:
     loose-envify "^1.0.0"
 
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
+
 whatwg-fetch@>=0.10.0:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
   integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
VEN-1481. Check the health of the Open City Profile API and the Berth API. When the Apollo federation server restarts, it may loose the schemas of the related datasources if the APIs are not available. To update the schemas, the Apollo federation gateway server needs to be restarted.