### PR TITLE
fix: increase header size

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "nodemon --ext ts --exec 'ts-node' src/index.ts",
     "transpile": "tsc",
-    "serve": "node --max-http-header-size=16000 dist/index.js",
+    "serve": "node --max-http-header-size=65535 dist/index.js",
     "test": "jest"
   },
   "author": "",


### PR DESCRIPTION
VEN-1583.

The Keycloak header becomse so huge for some AD-users that the header size needs to be set to really big.
